### PR TITLE
Keep it work if paren exists after receiver

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -134,7 +134,7 @@ module ErrorHighlight
       nd_recv, mid, nd_args = @node.children
       lineno = nd_recv.last_lineno
       lines = @fetch[lineno, @node.last_lineno]
-      if mid == :[] && lines.match(/\G\s*(\[(?:\s*\])?)/, nd_recv.last_column)
+      if mid == :[] && lines.match(/\G[\s)]*(\[(?:\s*\])?)/, nd_recv.last_column)
         @beg_column = $~.begin(1)
         @snippet = lines[/.*\n/]
         @beg_lineno = @end_lineno = lineno
@@ -143,11 +143,11 @@ module ErrorHighlight
             @end_column = $~.end(0)
           end
         else
-          if lines.match(/\G\s*?\[\s*\]/, nd_recv.last_column)
+          if lines.match(/\G[\s)]*?\[\s*\]/, nd_recv.last_column)
             @end_column = $~.end(0)
           end
         end
-      elsif lines.match(/\G\s*?(\&?\.)(\s*?)(#{ Regexp.quote(mid) }).*\n/, nd_recv.last_column)
+      elsif lines.match(/\G[\s)]*?(\&?\.)(\s*?)(#{ Regexp.quote(mid) }).*\n/, nd_recv.last_column)
         lines = $` + $&
         @beg_column = $~.begin($2.include?("\n") ? 3 : 1)
         @end_column = $~.end(3)
@@ -193,16 +193,16 @@ module ErrorHighlight
       nd_recv, mid, nd_args = @node.children
       *nd_args, _nd_last_arg, _nil = nd_args.children
       fetch_line(nd_recv.last_lineno)
-      if mid == :[]= && @snippet.match(/\G\s*(\[)/, nd_recv.last_column)
+      if mid == :[]= && @snippet.match(/\G[\s)]*(\[)/, nd_recv.last_column)
         @beg_column = $~.begin(1)
         args_last_column = $~.end(0)
         if nd_args.last && nd_recv.last_lineno == nd_args.last.last_lineno
           args_last_column = nd_args.last.last_column
         end
-        if @snippet.match(/\s*\]\s*=/, args_last_column)
+        if @snippet.match(/[\s)]*\]\s*=/, args_last_column)
           @end_column = $~.end(0)
         end
-      elsif @snippet.match(/\G\s*(\.\s*#{ Regexp.quote(mid.to_s.sub(/=\z/, "")) }\s*=)/, nd_recv.last_column)
+      elsif @snippet.match(/\G[\s)]*(\.\s*#{ Regexp.quote(mid.to_s.sub(/=\z/, "")) }\s*=)/, nd_recv.last_column)
         @beg_column = $~.begin(1)
         @end_column = $~.end(1)
       end
@@ -218,7 +218,7 @@ module ErrorHighlight
     def spot_attrasgn_for_args
       nd_recv, mid, nd_args = @node.children
       fetch_line(nd_recv.last_lineno)
-      if mid == :[]= && @snippet.match(/\G\s*\[/, nd_recv.last_column)
+      if mid == :[]= && @snippet.match(/\G[\s)]*\[/, nd_recv.last_column)
         @beg_column = $~.end(0)
         if nd_recv.last_lineno == nd_args.last_lineno
           @end_column = nd_args.last_column
@@ -240,7 +240,7 @@ module ErrorHighlight
       fetch_line(nd_recv.last_lineno)
       if nd_arg
         # binary operator
-        if @snippet.match(/\G\s*(#{ Regexp.quote(op) })/, nd_recv.last_column)
+        if @snippet.match(/\G[\s)]*(#{ Regexp.quote(op) })/, nd_recv.last_column)
           @beg_column = $~.begin(1)
           @end_column = $~.end(1)
         end
@@ -316,7 +316,7 @@ module ErrorHighlight
     def spot_op_asgn1_for_name
       nd_recv, op, nd_args, _nd_rhs = @node.children
       fetch_line(nd_recv.last_lineno)
-      if @snippet.match(/\G\s*(\[)/, nd_recv.last_column)
+      if @snippet.match(/\G[\s)]*(\[)/, nd_recv.last_column)
         bracket_beg_column = $~.begin(1)
         args_last_column = $~.end(0)
         if nd_args && nd_recv.last_lineno == nd_args.last_lineno
@@ -363,7 +363,7 @@ module ErrorHighlight
     def spot_op_asgn2_for_name
       nd_recv, _qcall, attr, op, _nd_rhs = @node.children
       fetch_line(nd_recv.last_lineno)
-      if @snippet.match(/\G\s*(\.)\s*#{ Regexp.quote(attr) }()\s*(#{ Regexp.quote(op) })(=)/, nd_recv.last_column)
+      if @snippet.match(/\G[\s)]*(\.)\s*#{ Regexp.quote(attr) }()\s*(#{ Regexp.quote(op) })(=)/, nd_recv.last_column)
         case @name
         when attr
           @beg_column = $~.begin(1)

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -65,6 +65,18 @@ undefined method `foo' for nil:NilClass
     end
   end
 
+  def test_CALL_noarg_4
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo' for nil:NilClass
+
+      (nil).foo + 1
+           ^^^^
+    END
+
+      (nil).foo + 1
+    end
+  end
+
   def test_CALL_arg_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `foo' for nil:NilClass
@@ -221,6 +233,18 @@ undefined method `[]' for #{ v.inspect }
     end
   end
 
+  def test_CALL_aref_5
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]' for nil:NilClass
+
+      (nil)[ ]
+           ^^^
+    END
+
+      (nil)[ ]
+    end
+  end
+
   def test_CALL_aset
     assert_error_message(NoMethodError, <<~END) do
 undefined method `[]=' for nil:NilClass
@@ -312,6 +336,30 @@ undefined method `foo=' for nil:NilClass
     end
   end
 
+  def test_ATTRASGN_4
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]=' for nil:NilClass
+
+      (nil)[0] = 42
+           ^^^^^
+    END
+
+      (nil)[0] = 42
+    end
+  end
+
+  def test_ATTRASGN_5
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo=' for nil:NilClass
+
+      (nil).foo = 42
+           ^^^^^^
+    END
+
+      (nil).foo = 42
+    end
+  end
+
   def test_OPCALL_binary_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `+' for nil:NilClass
@@ -337,7 +385,19 @@ undefined method `+' for nil:NilClass
     end
   end
 
-  def test_OPCALL_unary
+  def test_OPCALL_binary_3
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+' for nil:NilClass
+
+      (nil) + 42
+            ^
+    END
+
+      (nil) + 42
+    end
+  end
+
+  def test_OPCALL_unary_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `+@' for nil:NilClass
 
@@ -346,6 +406,18 @@ undefined method `+@' for nil:NilClass
     END
 
       + nil
+    end
+  end
+
+  def test_OPCALL_unary_2
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+@' for nil:NilClass
+
+      +(nil)
+      ^
+    END
+
+      +(nil)
     end
   end
 
@@ -428,6 +500,20 @@ undefined method `[]' for nil:NilClass
     end
   end
 
+  def test_OP_ASGN1_aref_4
+    v = nil
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]' for nil:NilClass
+
+      (v)[0] += 42
+         ^^^
+    END
+
+      (v)[0] += 42
+    end
+  end
+
   def test_OP_ASGN1_op_1
     v = Object.new
     def v.[](x); nil; end
@@ -471,6 +557,21 @@ undefined method `+' for nil:NilClass
         0
       ] +=
         42
+    end
+  end
+
+  def test_OP_ASGN1_op_4
+    v = Object.new
+    def v.[](x); nil; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+' for nil:NilClass
+
+      (v)[0] += 42
+             ^
+    END
+
+      (v)[0] += 42
     end
   end
 
@@ -520,6 +621,21 @@ undefined method `[]=' for #{ v.inspect }
     end
   end
 
+  def test_OP_ASGN1_aset_4
+    v = Object.new
+    def v.[](x); 1; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `[]=' for #{ v.inspect }
+
+      (v)[0] += 42
+         ^^^^^^
+    END
+
+      (v)[0] += 42
+    end
+  end
+
   def test_OP_ASGN2_read_1
     v = nil
 
@@ -546,6 +662,20 @@ undefined method `foo' for nil:NilClass
 
       v.foo += # comment
         42
+    end
+  end
+
+  def test_OP_ASGN2_read_3
+    v = nil
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo' for nil:NilClass
+
+      (v).foo += 42
+         ^^^^
+    END
+
+      (v).foo += 42
     end
   end
 
@@ -580,6 +710,21 @@ undefined method `+' for nil:NilClass
     end
   end
 
+  def test_OP_ASGN2_op_3
+    v = Object.new
+    def v.foo; nil; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `+' for nil:NilClass
+
+      (v).foo += 42
+              ^
+    END
+
+      (v).foo += 42
+    end
+  end
+
   def test_OP_ASGN2_write_1
     v = Object.new
     def v.foo; 1; end
@@ -608,6 +753,21 @@ undefined method `foo=' for #{ v.inspect }
 
       v.foo += # comment
         42
+    end
+  end
+
+  def test_OP_ASGN2_write_3
+    v = Object.new
+    def v.foo; 1; end
+
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo=' for #{ v.inspect }
+
+      (v).foo += 42
+         ^^^^^^^
+    END
+
+      (v).foo += 42
     end
   end
 


### PR DESCRIPTION
# Update

This PR focus on paren only. The following description is obsolate.


--------

This pull request fixes a problem that this gem doesn't work if parens, comments, and/or backslashes exist after the receiver.


It is under WIP because I need to support other nodes such as `OPCALL`.


# Problem



This gem doesn't display `^^^` if any non-space characters that don't make node exist. For example:


```ruby
(42).time

42
  # comment
  .time

42 \
  .time
```


The syntaxes don't make `RubyVM::AST` node, so `nd_recv.last_column` doesn't mean the position Immediately before the dot.