### PR TITLE
Only append highlight to Exception#to_s, not #message

### DIFF
--- a/lib/error_highlight/core_ext.rb
+++ b/lib/error_highlight/core_ext.rb
@@ -8,6 +8,11 @@ module ErrorHighlight
     SKIP_TO_S_FOR_SUPER_LOOKUP = true
     private_constant :SKIP_TO_S_FOR_SUPER_LOOKUP
 
+    def self.apply(error_class)
+      error_class.alias_method(:message, :to_s)
+      error_class.prepend(self)
+    end
+
     def to_s
       msg = super.dup
 
@@ -41,10 +46,10 @@ module ErrorHighlight
     end
   end
 
-  NameError.prepend(CoreExt)
+  CoreExt.apply(NameError)
 
   # The extension for TypeError/ArgumentError is temporarily disabled due to many test failures
 
-  #TypeError.prepend(CoreExt)
-  #ArgumentError.prepend(CoreExt)
+  # CoreExt.apply(TypeError)
+  # CoreExt.apply(ArgumentError)
 end

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -25,7 +25,7 @@ class ErrorHighlightTest < Test::Unit::TestCase
 
   def assert_error_message(klass, expected_msg, &blk)
     err = assert_raise(klass, &blk)
-    assert_equal(expected_msg.chomp, err.message)
+    assert_equal(expected_msg.chomp, err.to_s)
   end
 
   def test_CALL_noarg_1
@@ -1016,6 +1016,13 @@ _ _ ^^^^^
         load tmp.path
       end
     end
+  end
+
+  def test_message
+    error = assert_raises NoMethodError do
+      nil.foo
+    end
+    assert_equal "undefined method `foo' for nil:NilClass", error.message
   end
 
   def test_no_final_newline


### PR DESCRIPTION
I made a PR to showcase the idea, but I suppose there's many alternatives to this PR.

The issue I ran into when testing our app against ruby-head, is that we definitely disable `error_highlight` in production, however on CI it can be useful. But then it breaks lots of assertions about logs and error messages in our test suite.

Since ultimately the main goal of `error_highlight` is to show that extended message in things like IRB, etc, I'm thinking it could override `#to_s`, but leave `#message` untouched.

cc @mame what do you think?