### PR TITLE
Make it more robust against a spoofed filename

### DIFF
--- a/lib/error_highlight/core_ext.rb
+++ b/lib/error_highlight/core_ext.rb
@@ -29,7 +29,7 @@ module ErrorHighlight
 
         spot = ErrorHighlight.spot(node, **opts)
 
-      rescue Errno::ENOENT, SyntaxError
+      rescue StandardError, SyntaxError
       end
 
       if spot

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -1194,4 +1194,22 @@ undefined method `time' for 1:Integer
       end
     end
   end
+
+  def test_spoofed_filename
+    Tempfile.create(["error_highlight_test", ".rb"], binmode: true) do |tmp|
+      tmp << "module Dummy\nend\n"
+      tmp.close
+
+      assert_error_message(NameError, <<~END) do
+        undefined local variable or method `foo' for "dummy":String
+      END
+
+        "dummy".instance_eval do
+          eval <<-END, nil, tmp.path
+            foo
+          END
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, RubyVM::AST.of attempts to reopen a file based on iseq's file
path. However, it opens a wrong file if the iseq's file path is spoofed.

```
module Dummy
  binding.irb
end
```

```
$ ruby test.rb

From: test.rb @ line 2 :

    1: module Dummy
 => 2:   binding.irb
    3: end

irb(Dummy):001:0> foo
/home/mame/work/ruby/local/lib/ruby/3.1.0/error_highlight/base.rb:412:in `spot_colon2': undefined method `last_lineno' for nil:NilClass (NoMethodError)

      if nd_parent.last_lineno == @node.last_lineno
                  ^^^^^^^^^^^^
```

Found by @kateinoigakukun

Though this is a fundamental design issue of RubyVM::AST.of,
in any way it would be good to make error_highlight robust for
unexpected exception.

In a long term, this particular issue would be fixed by adding to irb an
option `RubyVM::ISeq.keep_script_lines = true` (which is not implemented
yet).