### PR TITLE
Handle nil nd_parent in spot_colon2

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -409,7 +409,7 @@ module ErrorHighlight
     #      ^^^^^
     def spot_colon2
       nd_parent, const = @node.children
-      if nd_parent.last_lineno == @node.last_lineno
+      if nd_parent&.last_lineno == @node.last_lineno
         fetch_line(nd_parent.last_lineno)
         @beg_column = nd_parent.last_column
         @end_column = @node.last_column


### PR DESCRIPTION
This fixes an issue in Sequel's tests on ruby 3.1.0-preview1, where a
test was showing the wrong output in an exception message.  The
related code rescues NameError to provide more information, then
reraises.  Here's the output of Sequel's test without changes to
error_highlight:

```
  1) Failure:
Sequel::Model::Associations::AssociationReflection::#associated_class#test_0006_should include association inspect output if an exception would be raised [/data/code/sequel/spec/model/associ
ation_reflection_spec.rb:75]:
Expected "undefined method `last_lineno' for nil:NilClass\n\n      if nd_parent.last_lineno == @node.last_lineno\n                  ^^^^^^^^^^^^" to include # encoding: UTF-8
"#<Sequel::Model::Associations::ManyToOneAssociationReflection #<Class:0x000002594112e458>.many_to_one :c>".
```

This change makes the Sequel test pass. There probably is a better
fix.

I tried to reproduce this outside of Sequel's tests in order to create
a test for error_highlight, but I wasn't able to do so quickly.