### PR TITLE
Fix type error on empty backtrace locations

### DIFF
--- a/lib/error_highlight/core_ext.rb
+++ b/lib/error_highlight/core_ext.rb
@@ -15,6 +15,7 @@ module ErrorHighlight
       return msg unless locs
 
       loc = locs.first
+      return msg unless loc
       begin
         node = RubyVM::AbstractSyntaxTree.of(loc, keep_script_lines: true)
         opts = {}

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -1194,4 +1194,20 @@ undefined method `time' for 1:Integer
       end
     end
   end
+
+  def test_simulate_funcallv_from_embedded_ruby
+    assert_error_message(NoMethodError, <<~END) do
+undefined method `foo' for nil:NilClass
+
+      nil.foo + 1
+         ^^^^
+    END
+
+      nil.foo + 1
+    rescue NoMethodError => exc
+      def exc.backtrace_locations = []
+      raise
+    end
+  end
+
 end

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -1198,9 +1198,6 @@ undefined method `time' for 1:Integer
   def test_simulate_funcallv_from_embedded_ruby
     assert_error_message(NoMethodError, <<~END) do
 undefined method `foo' for nil:NilClass
-
-      nil.foo + 1
-         ^^^^
     END
 
       nil.foo + 1


### PR DESCRIPTION
In `ErrorHighlight::CoreExt#to_s`, the `backtrace_locations` is checked before use, but that check doesn't cover all the cases.

If you happen to call directly `rb_funcallv` from a C program in an embedded Ruby scenario and an exception is raised, then the `backtrace_locations` will be an empty `Array`, not `nil`. In such an application, my error reporting code calls `to_s` on the `rb_errinfo()` value, and with Ruby 3.1 this results in a `TypeError: wrong argument type nil (expected method)` as the `ErrorHighlight::CoreExt#to_s` method uses a `loc` that is now `nil`.

I believe the correct thing to do here is to return `msg` as well.