### PR TITLE
Support nodes in `spot`

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -59,8 +59,7 @@ module ErrorHighlight
       Spotter.new(node, **opts).spot
 
     when RubyVM::AbstractSyntaxTree::Node
-      # Just for compatibility
-      Spotter.new(node, **opts).spot
+      Spotter.new(obj, **opts).spot
 
     else
       raise TypeError, "Exception is expected"


### PR DESCRIPTION
Fixes a bug where `spot` was using the wrong local variable.

We want to use error highlight with code that has been eval'd, specifically ERB templates. We can recover the compiled source code of the ERB template but we need an API to pass the node into error highlight's `spot`.

Required Ruby PR: https://github.com/ruby/ruby/pull/6593

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>