### PR TITLE
Enable ErrorHighlight for TypeError/ArgumentError only after Ruby 3.2

### DIFF
--- a/lib/error_highlight/core_ext.rb
+++ b/lib/error_highlight/core_ext.rb
@@ -37,6 +37,11 @@ module ErrorHighlight
   end
 
   NameError.prepend(CoreExt)
-  TypeError.prepend(CoreExt)
-  ArgumentError.prepend(CoreExt)
+
+  if Exception.method_defined?(:detailed_message)
+    # ErrorHighlight is enabled for TypeError and ArgumentError only when Exception#detailed_message is available.
+    # This is because changing ArgumentError#message is highly incompatible.
+    TypeError.prepend(CoreExt)
+    ArgumentError.prepend(CoreExt)
+  end
 end


### PR DESCRIPTION
... because changing TypeError#message and ArgumentError#message is highly incompatible.