### PR TITLE
Use ruby/actions workflow for ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,11 +9,18 @@ on:
       - 'master'
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 3.1
+
   build:
+    needs: ruby-versions
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'ruby-head', '3.1', '3.2' ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Previously, Ruby versions in `ruby.yml` were specified using an array. However, this PR has been changed to use the [ruby/actions](https://github.com/ruby/actions/blob/master/.github/workflows/ruby_versions.yml) workflow for version.