### PR TITLE
Load "did_you_mean" explicitly in test

### DIFF
--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -1,6 +1,7 @@
 require "test/unit"
 
 require "error_highlight"
+require "did_you_mean"
 require "tempfile"
 
 class ErrorHighlightTest < Test::Unit::TestCase


### PR DESCRIPTION
I'm not sure how it works, but I seem to get an error `undefined method 'formatter' for module DidYouMean` in parallel mode of `make test-all`.

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Ferror_highlight%2Ftest_error_highlight.rb%23class%3DErrorHighlightTest%23testcase%3Dtest_explicit_raise_name_error?organizationId=ruby&workspaceId=ruby&testPathId=file%3Dtest%2Ferror_highlight%2Ftest_error_highlight.rb%23class%3DErrorHighlightTest%23testcase%3Dtest_explicit_raise_name_error&testSessionStatus=flake