### PR TITLE
Fix error with prism when method given no arguments

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -700,6 +700,9 @@ module ErrorHighlight
     #   foo 42
     #       ^^
     def prism_spot_call_for_args
+      # Disallow highlighting arguments if there are no arguments.
+      return if @node.arguments.nil?
+
       # Explicitly turn off foo.() syntax because error_highlight expects this
       # to not work.
       return nil if @node.name == :call && @node.message_loc.nil?

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -197,6 +197,15 @@ undefined method `foo' for #{ NIL_RECV_MESSAGE }
     end
   end
 
+  def test_CALL_arg_7
+    assert_error_message(ArgumentError, <<~END) do
+tried to create Proc object without a block (ArgumentError)
+    END
+
+      Proc.new
+    end
+  end
+
   def test_QCALL_1
     assert_error_message(NoMethodError, <<~END) do
 undefined method `foo' for #{ ONE_RECV_MESSAGE }


### PR DESCRIPTION
such as:

  p = Proc.new

This is now highlighted, and it wasn't before.