### PR TITLE
Prism added node_id and Node#breadth_first_search in the 1.0 release.…

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -85,7 +85,7 @@ module ErrorHighlight
   # corresponding to the backtrace location in the source code.
   def self.prism_find(location)
     require "prism"
-    return nil if Prism::VERSION < "0.29.0"
+    return nil if Prism::VERSION < "1.0.0"
 
     absolute_path = location.absolute_path
     return unless absolute_path


### PR DESCRIPTION
Prism added node_id and Node#breadth_first_search in the 1.0 release. These methods are required for Prism to be able to find the method from the backtrace.

https://github.com/ruby/prism/blob/main/CHANGELOG.md#100---2024-08-28

In practice you will likely only end up in this situation if you previously had pre-1.0 prism installed and upgrade Ruby to a version with Prism as the default parser, but haven't upgraded Prism yet.

However, it is probably worth avoiding this error even for this very rare case.

cc: @kddnewton 