### PR TITLE
Handle very long lines

### DIFF
--- a/lib/error_highlight/formatter.rb
+++ b/lib/error_highlight/formatter.rb
@@ -1,5 +1,7 @@
 module ErrorHighlight
   class DefaultFormatter
+    MIN_SNIPPET_WIDTH = 20
+
     def self.message_for(spot)
       # currently only a one-line code snippet is supported
       return "" unless spot[:first_lineno] == spot[:last_lineno]
@@ -7,22 +9,24 @@ module ErrorHighlight
       snippet      = spot[:snippet]
       first_column = spot[:first_column]
       last_column  = spot[:last_column]
+      ellipsis     = "..."
 
       # truncate snippet to fit in the viewport
-      if snippet.size > viewport_size
-        visible_start = [first_column - viewport_size / 2, 0].max
-        visible_end   = visible_start + viewport_size
+      if snippet_max_width && snippet.size > snippet_max_width
+        available_width = snippet_max_width - ellipsis.size
+        center          = first_column - snippet_max_width / 2
 
-        # avoid centering the snippet when the error is at the end of the line
-        visible_start = snippet.size - viewport_size if visible_end > snippet.size
+        visible_start  = last_column < available_width ? 0 : [center, 0].max
+        visible_end    = visible_start + snippet_max_width
+        visible_start  = snippet.size - snippet_max_width if visible_end > snippet.size
 
-        prefix = visible_start.positive?    ? "..." : ""
-        suffix = visible_end < snippet.size ? "..." : ""
+        prefix = visible_start.positive?    ? ellipsis : ""
+        suffix = visible_end < snippet.size ? ellipsis : ""
 
         snippet = prefix + snippet[(visible_start + prefix.size)...(visible_end - suffix.size)] + suffix
         snippet << "\n" unless snippet.end_with?("\n")
 
-        first_column = first_column - visible_start
+        first_column -= visible_start
         last_column  = [last_column - visible_start, snippet.size - 1].min
       end
 
@@ -32,18 +36,31 @@ module ErrorHighlight
       "\n\n#{ snippet }#{ marker }"
     end
 
-    def self.viewport_size
-      Ractor.current[:__error_highlight_viewport_size__] ||= terminal_columns
+    def self.snippet_max_width
+      return if Ractor.current[:__error_highlight_max_snippet_width__] == :disabled
+
+      Ractor.current[:__error_highlight_max_snippet_width__] ||= terminal_width
     end
 
-    def self.viewport_size=(viewport_size)
-      Ractor.current[:__error_highlight_viewport_size__] = viewport_size
+    def self.snippet_max_width=(width)
+      return Ractor.current[:__error_highlight_max_snippet_width__] = :disabled if width.nil?
+
+      width = width.to_i
+
+      if width < MIN_SNIPPET_WIDTH
+        warn "'snippet_max_width' adjusted to minimum value of #{MIN_SNIPPET_WIDTH}."
+        width = MIN_SNIPPET_WIDTH
+      end
+
+      Ractor.current[:__error_highlight_max_snippet_width__] = width
     end
 
-    def self.terminal_columns
-      # lazy load io/console, so it's not loaded when viewport_size is set
+    def self.terminal_width
+      # lazy load io/console, so it's not loaded when snippet_max_width is set
       require "io/console"
-      IO.console.winsize[1]
+      STDERR.winsize[1] if STDERR.tty?
+    rescue LoadError, NoMethodError, SystemCallError
+      # do not truncate when window size is not available
     end
   end
 

--- a/lib/error_highlight/formatter.rb
+++ b/lib/error_highlight/formatter.rb
@@ -3,6 +3,8 @@ module ErrorHighlight
     def self.message_for(spot)
       # currently only a one-line code snippet is supported
       if spot[:first_lineno] == spot[:last_lineno]
+        spot = truncate(spot)
+
         indent = spot[:snippet][0...spot[:first_column]].gsub(/[^\t]/, " ")
         marker = indent + "^" * (spot[:last_column] - spot[:first_column])
 
@@ -10,6 +12,47 @@ module ErrorHighlight
       else
         ""
       end
+    end
+
+    def self.viewport_size
+      Ractor.current[:__error_highlight_viewport_size__] || terminal_columns
+    end
+
+    def self.viewport_size=(viewport_size)
+      Ractor.current[:__error_highlight_viewport_size__] = viewport_size
+    end
+
+    private
+    
+    def self.truncate(spot)
+      ellipsis = '...'
+      snippet = spot[:snippet]
+      diff = snippet.size - (viewport_size - ellipsis.size)
+
+      # snippet fits in the terminal
+      return spot if diff.negative?
+
+      if spot[:first_column] < diff
+        snippet = snippet[0...snippet.size - diff]
+        {
+          **spot,
+          snippet: snippet + ellipsis + "\n",
+          last_column: [spot[:last_column], snippet.size].min
+        }
+      else
+        {
+          **spot,
+          snippet: ellipsis + snippet[diff..-1],
+          first_column: spot[:first_column] - (diff - ellipsis.size),
+          last_column: spot[:last_column] - (diff - ellipsis.size)
+        }
+      end
+    end
+    
+    def self.terminal_columns
+      # lazy load io/console in case viewport_size is set
+      require "io/console"
+      IO.console.winsize[1]
     end
   end
 

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -12,6 +12,8 @@ class ErrorHighlightTest < Test::Unit::TestCase
   end
 
   def setup
+    ErrorHighlight::DefaultFormatter.viewport_size = 80
+
     if defined?(DidYouMean)
       @did_you_mean_old_formatter = DidYouMean.formatter
       DidYouMean.formatter = DummyFormatter
@@ -1282,6 +1284,30 @@ undefined method `time' for #{ ONE_RECV_MESSAGE }
 
         load tmp.path
       end
+    end
+  end
+
+  def test_errors_on_small_viewports_when_error_lives_at_the_end
+    assert_error_message(NoMethodError, <<~END) do
+undefined method 'gsuub' for an instance of String
+
+...ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo".gsuub(//, "")
+                                                                 ^^^^^^
+    END
+
+      "fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo".gsuub(//, "")
+    end
+  end
+
+  def test_errors_on_small_viewports_when_error_lives_at_the_beginning
+    assert_error_message(NoMethodError, <<~END) do
+undefined method 'gsuub' for an instance of Integer
+
+      1.gsuub(//, "fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo...
+       ^^^^^^
+    END
+
+      1.gsuub(//, "fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo")
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/ruby/error_highlight/issues/5

This PR updates the `ErrorHighlight::DefaultFormatter` to handle long lines. We're now identifying the number of columns in the terminal so that we can truncate the snippet and present it on a single line.

**Before**  
<img width="80%" src="https://github.com/user-attachments/assets/3b5690b3-87fd-42ad-a74a-ec7759f453ea">

**After**  
<img width="80%" src="https://github.com/user-attachments/assets/f9ad49e4-a28f-4a28-8afb-47d03479b7d4">
