### PR TITLE
Rename the `ErrorHighlight::DefaultFormatter` setting to `max_snippet_width` for clarity

### DIFF
--- a/lib/error_highlight/formatter.rb
+++ b/lib/error_highlight/formatter.rb
@@ -12,13 +12,13 @@ module ErrorHighlight
       ellipsis     = "..."
 
       # truncate snippet to fit in the viewport
-      if snippet_max_width && snippet.size > snippet_max_width
-        available_width = snippet_max_width - ellipsis.size
-        center          = first_column - snippet_max_width / 2
+      if max_snippet_width && snippet.size > max_snippet_width
+        available_width = max_snippet_width - ellipsis.size
+        center          = first_column - max_snippet_width / 2
 
         visible_start  = last_column < available_width ? 0 : [center, 0].max
-        visible_end    = visible_start + snippet_max_width
-        visible_start  = snippet.size - snippet_max_width if visible_end > snippet.size
+        visible_end    = visible_start + max_snippet_width
+        visible_start  = snippet.size - max_snippet_width if visible_end > snippet.size
 
         prefix = visible_start.positive?    ? ellipsis : ""
         suffix = visible_end < snippet.size ? ellipsis : ""
@@ -36,19 +36,19 @@ module ErrorHighlight
       "\n\n#{ snippet }#{ marker }"
     end
 
-    def self.snippet_max_width
+    def self.max_snippet_width
       return if Ractor.current[:__error_highlight_max_snippet_width__] == :disabled
 
       Ractor.current[:__error_highlight_max_snippet_width__] ||= terminal_width
     end
 
-    def self.snippet_max_width=(width)
+    def self.max_snippet_width=(width)
       return Ractor.current[:__error_highlight_max_snippet_width__] = :disabled if width.nil?
 
       width = width.to_i
 
       if width < MIN_SNIPPET_WIDTH
-        warn "'snippet_max_width' adjusted to minimum value of #{MIN_SNIPPET_WIDTH}."
+        warn "'max_snippet_width' adjusted to minimum value of #{MIN_SNIPPET_WIDTH}."
         width = MIN_SNIPPET_WIDTH
       end
 
@@ -56,7 +56,7 @@ module ErrorHighlight
     end
 
     def self.terminal_width
-      # lazy load io/console, so it's not loaded when snippet_max_width is set
+      # lazy load io/console, so it's not loaded when 'max_snippet_width' is set
       require "io/console"
       STDERR.winsize[1] if STDERR.tty?
     rescue LoadError, NoMethodError, SystemCallError

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -5,7 +5,7 @@ require "did_you_mean"
 require "tempfile"
 
 class ErrorHighlightTest < Test::Unit::TestCase
-  ErrorHighlight::DefaultFormatter.snippet_max_width = 80
+  ErrorHighlight::DefaultFormatter.max_snippet_width = 80
 
   class DummyFormatter
     def self.message_for(corrections)
@@ -1338,9 +1338,9 @@ undefined method `time' for #{ ONE_RECV_MESSAGE }
 
   def test_errors_on_extremely_small_terminal_window
     custom_max_width = 30
-    original_max_width = ErrorHighlight::DefaultFormatter.snippet_max_width
+    original_max_width = ErrorHighlight::DefaultFormatter.max_snippet_width
 
-    ErrorHighlight::DefaultFormatter.snippet_max_width = custom_max_width
+    ErrorHighlight::DefaultFormatter.max_snippet_width = custom_max_width
 
     assert_error_message(NoMethodError, <<~END) do
 undefined method `time' for #{ ONE_RECV_MESSAGE }
@@ -1352,14 +1352,14 @@ undefined method `time' for #{ ONE_RECV_MESSAGE }
       100000000000000 + 1.time { 100000000000000 }
     end
   ensure
-    ErrorHighlight::DefaultFormatter.snippet_max_width = original_max_width
+    ErrorHighlight::DefaultFormatter.max_snippet_width = original_max_width
   end
 
   def test_errors_on_terminal_window_smaller_than_min_width
     custom_max_width = 5
-    original_max_width = ErrorHighlight::DefaultFormatter.snippet_max_width
+    original_max_width = ErrorHighlight::DefaultFormatter.max_snippet_width
 
-    ErrorHighlight::DefaultFormatter.snippet_max_width = custom_max_width
+    ErrorHighlight::DefaultFormatter.max_snippet_width = custom_max_width
 
     assert_error_message(NoMethodError, <<~END) do
 undefined method `time' for #{ ONE_RECV_MESSAGE }
@@ -1371,14 +1371,14 @@ undefined method `time' for #{ ONE_RECV_MESSAGE }
     100000000000000 + 1.time { 100000000000000 }
     end
   ensure
-    ErrorHighlight::DefaultFormatter.snippet_max_width = original_max_width
+    ErrorHighlight::DefaultFormatter.max_snippet_width = original_max_width
   end
 
   def test_errors_on_terminal_window_when_truncation_is_disabled
     custom_max_width = nil
-    original_max_width = ErrorHighlight::DefaultFormatter.snippet_max_width
+    original_max_width = ErrorHighlight::DefaultFormatter.max_snippet_width
 
-    ErrorHighlight::DefaultFormatter.snippet_max_width = custom_max_width
+    ErrorHighlight::DefaultFormatter.max_snippet_width = custom_max_width
 
     assert_error_message(NoMethodError, <<~END) do
 undefined method `time' for #{ ONE_RECV_MESSAGE }
@@ -1390,7 +1390,7 @@ undefined method `time' for #{ ONE_RECV_MESSAGE }
       10000000000000000000000000000000000000000000000000000000000000000000000 + 1.time { 1000000000000000000000000000000 }
     end
   ensure
-    ErrorHighlight::DefaultFormatter.snippet_max_width = original_max_width
+    ErrorHighlight::DefaultFormatter.max_snippet_width = original_max_width
   end
 
   def test_errors_on_small_terminal_window_when_larger_than_viewport


### PR DESCRIPTION
Based on the https://github.com/ruby/error_highlight/pull/51#issuecomment-2430591183 thread, this PR updates the global setting for snippet truncation. We're moving from `ErrorHighlight::DefaultFormatter.snippet_max_width` to `ErrorHighlight::DefaultFormatter.max_snippet_width`.