### PR TITLE
Display error highlight in application code instead of gem files

### DIFF
--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -46,7 +46,14 @@ module ErrorHighlight
         locs = exc.backtrace_locations
         return nil unless locs
 
-        loc = locs.first
+        # Get only the base installation path from each 'Gem.path', so gem paths
+        # from the standard library are also considered.
+        gem_paths = defined?(Gem) ? Gem.path.map { |path| path.split("gems").first } : []
+
+        loc = locs.find do |loc|
+          gem_paths.none? { |path| loc.to_s.start_with?(path) }
+        end || locs.first
+
         return nil unless loc
 
         opts[:name] = exc.name if NameError === obj

--- a/test/test_error_highlight.rb
+++ b/test/test_error_highlight.rb
@@ -1417,6 +1417,18 @@ undefined method `timessssssssssssssssssssssssssssssssssssssssssssssssssssssssss
     end
   end
 
+  def test_errors_on_application_code_instead_of_gems
+    assert_error_message(TypeError, <<~END) do
+no implicit conversion of nil into String (TypeError)
+
+      JSON.parse(nil)
+                 ^^^
+    END
+      require "json"
+      JSON.parse(nil)
+    end
+  end
+
   def test_simulate_funcallv_from_embedded_ruby
     assert_error_message(NoMethodError, <<~END) do
 undefined method `foo' for #{ NIL_RECV_MESSAGE }


### PR DESCRIPTION
Fixes https://github.com/ruby/error_highlight/issues/35

This PR updates the `ErrorHighlight.spot` method to use the first line that doesn't belong to a Gem file.

**Before**
<img width="80%" src="https://github.com/user-attachments/assets/6a83f12a-67fa-4702-b29d-6a4468f5e1d3" />

**After**
<img width="80%" src="https://github.com/user-attachments/assets/24b6ade2-6bd6-4113-beb0-2ff8583ab752" />

