### PR TITLE
Use `$stderr` instead of STDERR for Ractor

### DIFF
--- a/lib/error_highlight/formatter.rb
+++ b/lib/error_highlight/formatter.rb
@@ -58,7 +58,7 @@ module ErrorHighlight
     def self.terminal_width
       # lazy load io/console, so it's not loaded when 'max_snippet_width' is set
       require "io/console"
-      STDERR.winsize[1] if STDERR.tty?
+      $stderr.winsize[1] if $stderr.tty?
     rescue LoadError, NoMethodError, SystemCallError
       # do not truncate when window size is not available
     end


### PR DESCRIPTION
Hello, 

I found that `ErrorHighlight::DefaultFormatter.terminal_width` can't be called from non-main Ractor.

```
$ ruby -Ilib -rerror_highlight -e 'Ractor.new { p ErrorHighlight.formatter.terminal_width }.take'
-e:1: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
#<Thread:0x00007fcde7022b98 run> terminated with exception (report_on_exception is true):
/home/wanabe/work/prog/ruby/error_highlight/lib/error_highlight/formatter.rb:61:in 'ErrorHighlight::DefaultFormatter.terminal_width': can not access non-shareable objects in constant ErrorHighlight::DefaultFormatter::STDERR by non-main Ractor. (Ractor::IsolationError)
        from -e:1:in 'block in <main>'
<internal:ractor>:711:in 'Ractor#take': thrown by remote Ractor. (Ractor::RemoteError)
        from -e:1:in '<main>'
/home/wanabe/work/prog/ruby/error_highlight/lib/error_highlight/formatter.rb:61:in 'ErrorHighlight::DefaultFormatter.terminal_width': can not access non-shareable objects in constant ErrorHighlight::DefaultFormatter::STDERR by non-main Ractor. (Ractor::IsolationError)
        from -e:1:in 'block in <main>'
```

Replacing `STDERR` to `$stderr` resolves this issue because `$stderr` is a ractor-local global variable.

```
$ ruby -Ilib -rerror_highlight -e 'Ractor.new { p ErrorHighlight.formatter.terminal_width }.take'
-e:1: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
104
```

How do you like it? Ijust want to solve the issue, so the method can be anything.